### PR TITLE
CakePHP4.3のFixtureアップグレード作業を実施

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,12 @@
     "require": {
         "php": ">=7.2",
         "cakephp/plugin-installer": "*",
-        "cakephp/cakephp": "~4.0"
+        "cakephp/cakephp": ">=4.3"
     },
     "require-dev": {
         "phpunit/phpunit": "*",
-        "cakephp/cakephp-codesniffer": "^4.5"
+        "cakephp/cakephp-codesniffer": "^4.5",
+        "cakephp/migrations": "^3.2"
     },
     "autoload": {
         "psr-4": {

--- a/config/schema/schema.sql
+++ b/config/schema/schema.sql
@@ -1,0 +1,28 @@
+-- sqlite schema.
+CREATE TABLE `users` (
+    `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+    `posts_count` integer NOT NULL DEFAULT 0,
+    `deleted` datetime DEFAULT NULL
+);
+
+CREATE TABLE `tags` (
+    `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+    `name` text DEFAULT NULL,
+    `deleted_date` datetime DEFAULT NULL
+);
+
+CREATE TABLE `posts` (
+    `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+    `user_id` integer NOT NULL DEFAULT 0,
+    `deleted` datetime DEFAULT NULL
+);
+CREATE INDEX `posts_user_id_idx` ON `posts`(`user_id`);
+
+CREATE TABLE `posts_tags` (
+    `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+    `post_id` integer DEFAULT NULL,
+    `tag_id` integer DEFAULT NULL,
+    `deleted` datetime DEFAULT NULL
+);
+CREATE INDEX `posts_tags_post_id_idx` ON `posts_tags`(`post_id`);
+CREATE INDEX `posts_tags_tag_id_idx` ON `posts_tags`(`tag_id`);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,15 +19,9 @@
     </testsuites>
 
     <!-- Setup a listener for fixtures -->
-    <listeners>
-        <listener
-        class="\Cake\TestSuite\Fixture\FixtureInjector"
-        file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
-            <arguments>
-                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
-            </arguments>
-        </listener>
-    </listeners>
+    <extensions>
+        <extension class="\Cake\TestSuite\Fixture\PHPUnitExtension" />
+    </extensions>
 
     <!-- Prevent coverage reports from looking in tests and vendors -->
     <filter>

--- a/tests/Fixture/PostsFixture.php
+++ b/tests/Fixture/PostsFixture.php
@@ -26,14 +26,6 @@ class PostsTable extends Table
 
 class PostsFixture extends TestFixture
 {
-    public $fields = [
-        'id'          => ['type' => 'integer'],
-        'user_id'     => ['type' => 'integer', 'default' => '0', 'null' => false],
-        'deleted'     => ['type' => 'datetime', 'default' => null, 'null' => true],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']]
-        ]
-    ];
     public $records = [
         [
             'id'          => 1,

--- a/tests/Fixture/PostsTagsFixture.php
+++ b/tests/Fixture/PostsTagsFixture.php
@@ -25,16 +25,6 @@ class PostsTagsTable extends Table
 
 class PostsTagsFixture extends TestFixture
 {
-    public $fields = [
-        'id' => ['type' => 'integer'],
-        'post_id' => ['type' => 'integer'],
-        'tag_id' => ['type' => 'integer'],
-        'deleted'     => ['type' => 'datetime', 'default' => null, 'null' => true],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']]
-        ]
-    ];
-
     public $records = [
         [
             'id' => 1,

--- a/tests/Fixture/TagsFixture.php
+++ b/tests/Fixture/TagsFixture.php
@@ -32,15 +32,6 @@ class TagsTable extends Table
 
 class TagsFixture extends TestFixture
 {
-    public $fields = [
-        'id'          => ['type' => 'integer'],
-        'name'     => ['type' => 'string'],
-        'deleted_date'     => ['type' => 'datetime', 'default' => null, 'null' => true],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']]
-        ]
-    ];
-
     public $records = [
         [
             'id' => 1,

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -26,14 +26,6 @@ class UsersTable extends Table
 
 class UsersFixture extends TestFixture
 {
-    public $fields = [
-        'id'          => ['type' => 'integer'],
-        'posts_count'  => ['type' => 'integer', 'default' => '0', 'null' => false],
-        'deleted'     => ['type' => 'datetime', 'default' => null, 'null' => true],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']]
-        ]
-    ];
     public $records = [
         [
             'id'          => 1,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,6 +33,10 @@ require_once $root . '/vendor/autoload.php';
  */
 require_once $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
 
+$schema_path = dirname(__DIR__) . DS . 'config' . DS . 'schema' . DS . 'schema.sql';
+(new \Migrations\TestSuite\Migrator())->run();
+(new \Cake\TestSuite\Fixture\SchemaLoader())->loadSqlFiles($schema_path, 'test');
+
 if (file_exists($root . '/config/bootstrap.php')) {
     require $root . '/config/bootstrap.php';
 


### PR DESCRIPTION
4.3移行ガイド
https://book.cakephp.org/4/ja/appendices/4-3-migration-guide.html

4.3Fixtureのアップグレード
https://book.cakephp.org/4/ja/appendices/fixture-upgrade.html

プラグイン内から親の接続設定の参照はできない気がするためデフォルトのデータベース（sqlite）用スキーマ情報が必要と思われる
tests/bootstrap.php内でmigrationsプラグインのMigratorクラスを使用するためをcomposerで追加
あとは移行ガイドの通りに修正

その他、composer.jsonについてcakephp本体の最小バージョンを4.3に変更